### PR TITLE
feat: adding clean up step in kubernetes workflow

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -179,6 +179,12 @@ jobs:
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+      - name: Clean up images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: ${{ github.event.deployment.payload.name }}
+          package-type: container
+          min-versions-to-keep: ${{ github.event.deployment.payload.env == 'prod' && '50' || '5' }}
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://parcellab.atlassian.net/browse/INF-1154

## Description

Currently every image ever built is retained in Github packages. This increases cost, as we are exceeding our included capacity. 

Old images need to be expired from Github packages.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
