### PR TITLE
feat: add build and push image GHA

### DIFF
--- a/.github/workflows/build-and-push-image-to-ecr.yaml
+++ b/.github/workflows/build-and-push-image-to-ecr.yaml
@@ -6,6 +6,7 @@ on:
       APPLICATION_NAME:
         description: The name of the application
         required: true
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true

--- a/.github/workflows/build-and-push-image-to-ecr.yaml
+++ b/.github/workflows/build-and-push-image-to-ecr.yaml
@@ -1,0 +1,47 @@
+name: Build and push image from the PR to ECR
+
+on:
+  workflow_call:
+    inputs:
+      APPLICATION_NAME:
+        description: The name of the application
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+jobs:
+  build-and-push-image-to-ecr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current git repository
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: Create ECR repository if it doesn't exist
+        run: |
+          aws ecr describe-repositories --repository-names ${{ inputs.APPLICATION_NAME }} || \
+          aws ecr create-repository --repository-name ${{ inputs.APPLICATION_NAME }}
+          LIFECYCLE_POLICY='{"rules":[{"rulePriority":1,"description":"Keep last 500 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":500},"action":{"type":"expire"}}]}'
+          aws ecr put-lifecycle-policy --repository-name ${{ inputs.APPLICATION_NAME }} --lifecycle-policy-text "$LIFECYCLE_POLICY"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push to repository
+        uses: docker/build-push-action@v6
+        with:
+          file: Containerfile
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.APPLICATION_NAME }}:preview
+            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.APPLICATION_NAME }}:${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Adding reusable GHA workflow to build and push image to ECR.
Doing this for preview environments but it can be used in other scenarios as well.