### PR TITLE
feat: add second image build step for kubernetes workflow

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -125,7 +125,6 @@ on:
         description: AWS Account ID
 jobs:
   parallel:
-    needs: [load-deployment-vars]
     environment: ${{ github.event.deployment.payload.env }}
     # concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -27,6 +27,14 @@ on:
         description: The repository within Github that holds the version file to deploy via GitOps
         default: parcelLab/deployment
         type: string
+      imageTargetPrimary:
+        required: false
+        description: If provided, sets a target for primary image build
+        type: string
+      imageTargetAdditional:
+        required: false
+        description: If provided, sets a target for secondary image build
+        type: string
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).
@@ -200,6 +208,28 @@ jobs:
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+          target: ${{ inputs.imageTargetPrimary }}
+      - name: Build and push latest version to GitHub
+        if: inputs.repository_kind == 'github' && inputs.imageTargetAdditional != ''
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            VERSION=${{ steps.vars.outputs.version }}
+            APP_NAME=${{ github.event.deployment.payload.name }}
+            ENVIRONMENT=${{ github.event.deployment.payload.env }}
+            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
+          cache-to: type=inline
+          context: ${{ github.event.deployment.payload.container.context }}
+          file: ${{ github.event.deployment.payload.container.file }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+          target: ${{ inputs.imageTargetAdditional }}
       - name: Configure AWS credentials
         if: inputs.repository_kind == 'ecr'
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -188,7 +188,7 @@ jobs:
           registry: ${{ inputs.registryHostname }}
           username: ${{ inputs.registryUsername }}
           password: ${{ secrets.repoAccessToken }}
-      - name: Build and push latest version to GitHub
+      - name: Build and push primary image to GitHub
         if: inputs.repository_kind == 'github'
         uses: docker/build-push-action@v6
         with:
@@ -209,7 +209,7 @@ jobs:
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
           target: ${{ inputs.imageTargetPrimary }}
-      - name: Build and push latest version to GitHub
+      - name: Build and push additional image to GitHub
         if: inputs.repository_kind == 'github' && inputs.imageTargetAdditional != ''
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -236,12 +236,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: Create ECR repository if it doesn't exist
-        if: inputs.repository_kind == 'ecr'
+        if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets == ''
         run: |
           aws ecr describe-repositories --repository-names ${{ github.event.deployment.payload.name }} || \
           aws ecr create-repository --repository-name ${{ github.event.deployment.payload.name }}
           LIFECYCLE_POLICY='{"rules":[{"rulePriority":1,"description":"Keep last 500 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":500},"action":{"type":"expire"}}]}'
           aws ecr put-lifecycle-policy --repository-name ${{ github.event.deployment.payload.name }} --lifecycle-policy-text "$LIFECYCLE_POLICY"
+      - name: Create ECR repository if it doesn't exist
+        if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets != ''
+        run: |
+          aws ecr describe-repositories --repository-names ${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }} || \
+          aws ecr create-repository --repository-name ${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}
+          LIFECYCLE_POLICY='{"rules":[{"rulePriority":1,"description":"Keep last 500 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":500},"action":{"type":"expire"}}]}'
+          aws ecr put-lifecycle-policy --repository-name ${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }} --lifecycle-policy-text "$LIFECYCLE_POLICY"
       - name: Login to Amazon ECR
         if: inputs.repository_kind == 'ecr'
         id: login-ecr

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -126,7 +126,7 @@ on:
 jobs:
   kubernetes:
     environment: ${{ github.event.deployment.payload.env }}
-    concurrency: ${{ github.event.deployment.payload.env }}-matrix
+    concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -126,7 +126,7 @@ on:
 jobs:
   kubernetes:
     environment: ${{ github.event.deployment.payload.env }}
-    concurrency: ${{ github.event.deployment.payload.env }}
+    concurrency: ${{ github.event.deployment.payload.env }}-matrix
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -30,7 +30,7 @@ on:
       imageTargets:
         required: false
         description: If provided, sets targets for as many image builds as targets specified
-        type: list
+        type: array
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).
@@ -188,7 +188,27 @@ jobs:
           username: ${{ inputs.registryUsername }}
           password: ${{ secrets.repoAccessToken }}
       - name: Build and push primary image to GitHub
-        if: inputs.repository_kind == 'github'
+        if: inputs.repository_kind == 'github' && matrix.containerfile_targets == ''
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            VERSION=${{ steps.vars.outputs.version }}
+            APP_NAME=${{ github.event.deployment.payload.name }}
+            ENVIRONMENT=${{ github.event.deployment.payload.env }}
+            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
+          cache-to: type=inline
+          context: ${{ github.event.deployment.payload.container.context }}
+          file: ${{ github.event.deployment.payload.container.file }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+      - name: Build and push primary image to GitHub
+        if: inputs.repository_kind == 'github' && matrix.containerfile_targets != ''
         uses: docker/build-push-action@v6
         with:
           build-args: |
@@ -227,7 +247,27 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
       - name: Build and push primary image to ECR
-        if: inputs.repository_kind == 'ecr'
+        if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets == ''
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            VERSION=${{ steps.vars.outputs.version }}
+            APP_NAME=${{ github.event.deployment.payload.name }}
+            ENVIRONMENT=${{ github.event.deployment.payload.env }}
+            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
+          cache-to: type=inline
+          context: ${{ github.event.deployment.payload.container.context }}
+          file: ${{ github.event.deployment.payload.container.file }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+      - name: Build and push primary image to ECR
+        if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets != ''
         uses: docker/build-push-action@v6
         with:
           build-args: |

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -248,7 +248,7 @@ jobs:
         if: inputs.repository_kind == 'ecr'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push latest version to ECR
+      - name: Build and push primary image to ECR
         if: inputs.repository_kind == 'ecr'
         uses: docker/build-push-action@v6
         with:
@@ -268,6 +268,28 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+          target: ${{ inputs.imageTargetPrimary }}
+      - name: Build and push additional image to ECR
+        if: inputs.repository_kind == 'ecr' && inputs.imageTargetAdditional != ''
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            VERSION=${{ steps.vars.outputs.version }}
+            APP_NAME=${{ github.event.deployment.payload.name }}
+            ENVIRONMENT=${{ github.event.deployment.payload.env }}
+            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
+          cache-to: type=inline
+          context: ${{ github.event.deployment.payload.container.context }}
+          file: ${{ github.event.deployment.payload.container.file }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+          target: ${{ inputs.imageTargetAdditional }}
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -226,9 +226,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:latest
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:${{ steps.vars.outputs.version }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:${{ github.sha }}
           target: ${{ inputs.imageTargetAdditional }}
       - name: Configure AWS credentials
         if: inputs.repository_kind == 'ecr'

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -124,7 +124,7 @@ on:
         required: true
         description: AWS Account ID
 jobs:
-  kubernetes:
+  parallel:
     environment: ${{ github.event.deployment.payload.env }}
     # concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
@@ -155,6 +155,7 @@ jobs:
             # shellcheck disable=SC2086
             echo "channel-id=${{ inputs.slackChannelStaging }}" >> $GITHUB_OUTPUT
           fi
+
       - name: Start ${{ github.event.deployment.payload.name }} deployment
         uses: chrnorm/deployment-status@v2
         with:
@@ -294,6 +295,11 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ steps.vars.outputs.version }}
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ github.sha }}
           target: ${{ matrix.containerfile_targets }}
+  consecutive:
+    needs: [parallel]
+    environment: ${{ github.event.deployment.payload.env }}
+    runs-on: ${{ inputs.runner }}
+      steps:
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
         uses: actions/checkout@v3
         with:
@@ -306,19 +312,19 @@ jobs:
         name: Update ${{ github.event.deployment.payload.name }} version for ${{ github.event.deployment.environment }} values
         uses: mikefarah/yq@v4.30.8
         with:
-          cmd: yq '(.${{ github.event.deployment.payload.chart }}.image.tag = "${{ steps.vars.outputs.version }}")' -i remote/${{ inputs.deploymentRepoPath }}/${{ github.event.deployment.payload.namespace }}/${{ github.event.deployment.payload.env }}/${{ github.event.deployment.payload.name }}/${{ inputs.versionFilePath }}
+          cmd: yq '(.${{ github.event.deployment.payload.chart }}.image.tag = "${{ needs.parallel.outputs.version }}")' -i remote/${{ inputs.deploymentRepoPath }}/${{ github.event.deployment.payload.namespace }}/${{ github.event.deployment.payload.env }}/${{ github.event.deployment.payload.name }}/${{ inputs.versionFilePath }}
       - if: github.event.deployment.payload.schemaVersion == 'v2'
         name: Update ${{ github.event.deployment.payload.name }} version for ${{ github.event.deployment.environment }} values
         uses: mikefarah/yq@v4.30.8
         with:
-          cmd: yq '(.${{ github.event.deployment.payload.kubernetes.versionKey }} = "${{ steps.vars.outputs.version }}")' -i remote/${{ inputs.deploymentRepoPath }}/${{ github.event.deployment.payload.kubernetes.namespace }}/${{ github.event.deployment.payload.env }}/${{ github.event.deployment.payload.name }}/${{ inputs.versionFilePath }}
+          cmd: yq '(.${{ github.event.deployment.payload.kubernetes.versionKey }} = "${{ needs.parallel.outputs.version }}")' -i remote/${{ inputs.deploymentRepoPath }}/${{ github.event.deployment.payload.kubernetes.namespace }}/${{ github.event.deployment.payload.env }}/${{ github.event.deployment.payload.name }}/${{ inputs.versionFilePath }}
       - name: Commit deployment file
         run: |
           cd remote
           git config --global user.email "${{ inputs.botEmail }}"
           git config --global user.name "${{ inputs.registryUsername }}"
           git add .
-          git commit --allow-empty -m "chore(${{ github.event.deployment.payload.name }}): set ${{ github.event.deployment.payload.env }} version to ${{ steps.vars.outputs.version }}"
+          git commit --allow-empty -m "chore(${{ github.event.deployment.payload.name }}): set ${{ github.event.deployment.payload.env }} version to ${{ needs.parallel.outputs.version }}"
       - name: Push changes to ${{ inputs.deploymentRepoURL }} git repository
         uses: ad-m/github-push-action@0fafdd62b84042d49ec0cb92d9cac7f7ce4ec79e
         with:
@@ -345,14 +351,14 @@ jobs:
           environment: ${{ github.event.deployment.payload.env }}
           state: "failure"
           token: ${{ github.token }}
-      - if: success() && steps.vars.outputs.channel-id != ''
+      - if: success() && needs.parallel.outputs.channel-id != ''
         name: Notify ${{ github.event.deployment.payload.name }} deployment success
         continue-on-error: true
         uses: darioblanco/slack-deployment@main
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slackBotToken }}
         with:
-          channel_id: ${{ steps.vars.outputs.channel-id }}
+          channel_id: ${{ needs.parallel.outputs.channel-id }}
           deployment_description: ${{ github.event.deployment.payload.description == null && 'No description' || github.event.deployment.payload.description }}
           deployment_name: ${{ github.event.deployment.payload.name == null && 'unknown' || github.event.deployment.payload.name }}
           environment: ${{ github.event.deployment.payload.env == null && 'unknown' || github.event.deployment.payload.env }}
@@ -363,7 +369,7 @@ jobs:
           sha: ${{ github.sha }}
           status_url: ${{ github.event.deployment.payload.statusUrl == null && 'https://github.com' || github.event.deployment.payload.statusUrl }}
           url: ${{ github.event.deployment.payload.url == null && 'https://github.com' || github.event.deployment.payload.url }}
-          version: ${{ steps.vars.outputs.version }}
+          version: ${{ needs.parallel.outputs.version }}
       - if: success() && inputs.sentryOrg != '' && inputs.sentryProject != ''
         name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -375,7 +381,7 @@ jobs:
         with:
           environment: ${{ inputs.sentryEnvironment != '' && inputs.sentryEnvironment || github.event.deployment.payload.env }}
           set_commits: skip
-          version: ${{ steps.vars.outputs.version }}
+          version: ${{ needs.parallel.outputs.version }}
         continue-on-error: true
       - name: Clean up images
         uses: actions/delete-package-versions@v4

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -30,7 +30,7 @@ on:
       imageTargets:
         required: false
         description: If provided, sets targets for as many image builds as targets specified
-        type: string
+        type: array
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -30,7 +30,7 @@ on:
       imageTargets:
         required: false
         description: If provided, sets targets for as many image builds as targets specified
-        type: array
+        type: string
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).
@@ -130,7 +130,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:
-        containerfile_targets: ${{ inputs.imageTargets }}
+        containerfile_targets: ${{ fromJson(inputs.imageTargets) }}
     steps:
       - name: Load deployment variables
         id: vars

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -27,14 +27,10 @@ on:
         description: The repository within Github that holds the version file to deploy via GitOps
         default: parcelLab/deployment
         type: string
-      imageTargetPrimary:
+      imageTargets:
         required: false
-        description: If provided, sets a target for primary image build
-        type: string
-      imageTargetAdditional:
-        required: false
-        description: If provided, sets a target for secondary image build
-        type: string
+        description: If provided, sets targets for as many image builds as targets specified
+        type: list
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).
@@ -132,6 +128,9 @@ jobs:
     environment: ${{ github.event.deployment.payload.env }}
     concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
+    strategy:
+      matrix:
+        containerfile_targets: ${{ inputs.imageTargets }}
     steps:
       - name: Load deployment variables
         id: vars
@@ -205,31 +204,10 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
-          target: ${{ inputs.imageTargetPrimary }}
-      - name: Build and push additional image to GitHub
-        if: inputs.repository_kind == 'github' && inputs.imageTargetAdditional != ''
-        uses: docker/build-push-action@v6
-        with:
-          build-args: |
-            GITHUB_SHA=${{ github.sha }}
-            VERSION=${{ steps.vars.outputs.version }}
-            APP_NAME=${{ github.event.deployment.payload.name }}
-            ENVIRONMENT=${{ github.event.deployment.payload.env }}
-            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
-          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
-          cache-to: type=inline
-          context: ${{ github.event.deployment.payload.container.context }}
-          file: ${{ github.event.deployment.payload.container.file }}
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:latest
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:${{ steps.vars.outputs.version }}
-            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ inputs.imageTargetAdditional }}:${{ github.sha }}
-          target: ${{ inputs.imageTargetAdditional }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:latest
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ steps.vars.outputs.version }}
+            ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ github.sha }}
+          target: ${{ matrix.containerfile_targets }}
       - name: Configure AWS credentials
         if: inputs.repository_kind == 'ecr'
         uses: aws-actions/configure-aws-credentials@v2
@@ -265,31 +243,10 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
-          target: ${{ inputs.imageTargetPrimary }}
-      - name: Build and push additional image to ECR
-        if: inputs.repository_kind == 'ecr' && inputs.imageTargetAdditional != ''
-        uses: docker/build-push-action@v6
-        with:
-          build-args: |
-            GITHUB_SHA=${{ github.sha }}
-            VERSION=${{ steps.vars.outputs.version }}
-            APP_NAME=${{ github.event.deployment.payload.name }}
-            ENVIRONMENT=${{ github.event.deployment.payload.env }}
-            NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
-          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}
-          cache-to: type=inline
-          context: ${{ github.event.deployment.payload.container.context }}
-          file: ${{ github.event.deployment.payload.container.file }}
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
-          target: ${{ inputs.imageTargetAdditional }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:latest
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ steps.vars.outputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }}:${{ github.sha }}
+          target: ${{ matrix.containerfile_targets }}
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -190,7 +190,7 @@ jobs:
           registry: ${{ inputs.registryHostname }}
           username: ${{ inputs.registryUsername }}
           password: ${{ secrets.repoAccessToken }}
-      - name: Build and push primary image to GitHub
+      - name: Build and push image to GitHub
         if: inputs.repository_kind == 'github' && matrix.containerfile_targets == ''
         uses: docker/build-push-action@v6
         with:
@@ -210,7 +210,7 @@ jobs:
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:latest
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ inputs.registryHostname }}/${{ inputs.registryOrg }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
-      - name: Build and push primary image to GitHub
+      - name: Build and push ${{ matrix.containerfile_targets }} image to GitHub
         if: inputs.repository_kind == 'github' && matrix.containerfile_targets != ''
         uses: docker/build-push-action@v6
         with:
@@ -245,7 +245,7 @@ jobs:
           aws ecr create-repository --repository-name ${{ github.event.deployment.payload.name }}
           LIFECYCLE_POLICY='{"rules":[{"rulePriority":1,"description":"Keep last 500 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":500},"action":{"type":"expire"}}]}'
           aws ecr put-lifecycle-policy --repository-name ${{ github.event.deployment.payload.name }} --lifecycle-policy-text "$LIFECYCLE_POLICY"
-      - name: Create ECR repository if it doesn't exist
+      - name: Create ${{ matrix.containerfile_targets }} ECR repository if it doesn't exist
         if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets != ''
         run: |
           aws ecr describe-repositories --repository-names ${{ github.event.deployment.payload.name }}-${{ matrix.containerfile_targets }} || \
@@ -256,7 +256,7 @@ jobs:
         if: inputs.repository_kind == 'ecr'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push primary image to ECR
+      - name: Build and push image to ECR
         if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets == ''
         uses: docker/build-push-action@v6
         with:
@@ -276,7 +276,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:latest
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ steps.vars.outputs.version }}
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.deployment.payload.name }}:${{ github.sha }}
-      - name: Build and push primary image to ECR
+      - name: Build and push ${{ matrix.containerfile_targets }} image to ECR
         if: inputs.repository_kind == 'ecr' && matrix.containerfile_targets != ''
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -30,7 +30,7 @@ on:
       imageTargets:
         required: false
         description: If provided, sets targets for as many image builds as targets specified
-        type: array
+        type: string
       preScript:
         required: false
         description: If provided, runs a script after repo checkout and before the docker image is built. Useful in case that you need to build a package outside of the docker image (and load the artifacts via copy).

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -126,7 +126,7 @@ on:
 jobs:
   kubernetes:
     environment: ${{ github.event.deployment.payload.env }}
-    concurrency: ${{ github.event.deployment.payload.env }}
+    # concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -299,7 +299,7 @@ jobs:
     needs: [parallel]
     environment: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
-      steps:
+    steps:
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -125,12 +125,16 @@ on:
         description: AWS Account ID
 jobs:
   parallel:
+    needs: [load-deployment-vars]
     environment: ${{ github.event.deployment.payload.env }}
     # concurrency: ${{ github.event.deployment.payload.env }}
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:
         containerfile_targets: ${{ fromJson(inputs.imageTargets) }}
+    outputs:
+      channel-id: ${{ steps.vars.outputs.channel-id }}
+      version: ${{ steps.vars.outputs.version }}
     steps:
       - name: Load deployment variables
         id: vars
@@ -155,7 +159,6 @@ jobs:
             # shellcheck disable=SC2086
             echo "channel-id=${{ inputs.slackChannelStaging }}" >> $GITHUB_OUTPUT
           fi
-
       - name: Start ${{ github.event.deployment.payload.name }} deployment
         uses: chrnorm/deployment-status@v2
         with:


### PR DESCRIPTION
* Specifying target names causes corresponding amount of image builds in parallel
* Target name is used for both specifying target in Containerfile and appending it to the image name at the end
* All images have the same commit_sha tag
* Commit and push new tag steps (and all consecutive ones) are moved to a separate job

* Tested on `flask-blueprint-app` https://github.com/parcelLab/flask-blueprint-app/pull/23
 