### PR TITLE
fix: pipeline cache setting for ecr builds

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -173,7 +173,8 @@ jobs:
             ENVIRONMENT=${{ github.event.deployment.payload.env }}
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
           cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
-          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
+          cache-to: type=inline
+          #          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}
@@ -314,7 +315,8 @@ jobs:
             ENVIRONMENT=${{ github.event.deployment.payload.env }}
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
           cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
-          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
+          cache-to: type=inline
+          #          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -172,8 +172,8 @@ jobs:
             APP_NAME=${{ github.event.deployment.payload.name }}
             ENVIRONMENT=${{ github.event.deployment.payload.env }}
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
-          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}
-          cache-to: type=inline
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
+          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}
@@ -313,8 +313,8 @@ jobs:
             APP_NAME=${{ github.event.deployment.payload.name }}
             ENVIRONMENT=${{ github.event.deployment.payload.env }}
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
-          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}
-          cache-to: type=inline
+          cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
+          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -174,7 +174,6 @@ jobs:
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
           cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
           cache-to: type=inline
-          #          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}
@@ -316,7 +315,6 @@ jobs:
             NPM_GITHUB_TOKEN=${{ secrets.npmGithubReadToken }}
           cache-from: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache
           cache-to: type=inline
-          #          cache-to: type=registry,ref=${{ inputs.registryHostname }}/${{ github.event.deployment.payload.name }}:cache,mode=max
           context: ${{ github.event.deployment.payload.container.context }}
           load: true
           file: ${{ github.event.deployment.payload.container.file }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -178,7 +178,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml@33f6d1e4985443ae9aea8819a207fa6130659d4a
+    uses: parcelLab/ci/.github/workflows/build-image.yaml@main
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -178,7 +178,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml@8ccb8bb981abe41ea7172f65f4664a3beaaa9f70
+    uses: parcelLab/ci/.github/workflows/build-image.yaml@33f6d1e4985443ae9aea8819a207fa6130659d4a
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -178,7 +178,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml@main
+    uses: parcelLab/ci/.github/workflows/build-image.yaml@8ccb8bb981abe41ea7172f65f4664a3beaaa9f70
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}


### PR DESCRIPTION
Apparently ECR needs an image tag to keep the cache on