### PR TITLE
fix: commit on same repo not in parallel

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -207,7 +207,6 @@ jobs:
     needs: [initialize, build]
     environment: ${{ github.event.deployment.payload.env }}
     concurrency: commit-${{ inputs.deploymentRepoURL }}-${{ github.sha }}
-    cancel-in-progress: false
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -206,6 +206,8 @@ jobs:
   commit:
     needs: [initialize, build]
     environment: ${{ github.event.deployment.payload.env }}
+    concurrency: commit-${{ inputs.deploymentRepoURL }}-${{ github.sha }}
+    cancel-in-progress: false
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository


### PR DESCRIPTION
If a service repo uses the pipelines to trigger parallel deployments (e.g. staging and prod) the commit steps might interfere with each other. This change should make them wait for each other.