### PR TITLE
feat: add optional base image registry for kubernetes workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -43,6 +43,9 @@ on:
       npmGithubReadToken:
         required: true
         description: The Github token with permissions to read NPM private packages
+      AWS_ROLE_TO_ASSUME:
+        required: true
+        description: AWS OIDC role for GitHub to assume
       baseImageRegistryUsername:
         required: false
         description: The username for the base image registry

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -32,9 +32,26 @@ on:
         description: Runner type
         default: ubuntu-latest
         type: string
+      baseImageRegistry:
+        required: false
+        description: The registry to pull base images from
+        type: string
       version:
         required: true
         type: string
+    secrets:
+      npmGithubReadToken:
+        required: true
+        description: The Github token with permissions to read NPM private packages
+      AWS_ROLE_TO_ASSUME:
+        required: true
+        description: AWS OIDC role for GitHub to assume
+      baseImageRegistryUsername:
+        required: false
+        description: The username for the base image registry
+      baseImageRegistryPassword:
+        required: false
+        description: The password for the base image registry
 
 env:
   IMAGE_SCAN_SEVERITY: LOW
@@ -66,6 +83,20 @@ jobs:
         with:
           name: ${{ inputs.artifactName }}
           path: ${{ inputs.artifactPath }}
+      - name: Validate base image registry secrets
+        if: ${{ inputs.baseImageRegistry }}
+        run: |
+          if [ -z "${{ secrets.baseImageRegistryUsername }}" ] || [ -z "${{ secrets.baseImageRegistryPassword }}" ]; then
+            echo "baseImageRegistry is set but baseImageRegistryUsername or baseImageRegistryPassword secrets are missing."
+            exit 1
+          fi
+      - name: Login to base image registry
+        if: ${{ inputs.baseImageRegistry }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.baseImageRegistry }}
+          username: ${{ secrets.baseImageRegistryUsername }}
+          password: ${{ secrets.baseImageRegistryPassword }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Configure AWS credentials
@@ -153,6 +184,20 @@ jobs:
         with:
           name: ${{ inputs.artifactName }}
           path: ${{ inputs.artifactPath }}
+      - name: Validate base image registry secrets
+        if: ${{ inputs.baseImageRegistry }}
+        run: |
+          if [ -z "${{ secrets.baseImageRegistryUsername }}" ] || [ -z "${{ secrets.baseImageRegistryPassword }}" ]; then
+            echo "baseImageRegistry is set but baseImageRegistryUsername or baseImageRegistryPassword secrets are missing."
+            exit 1
+          fi
+      - name: Login to base image registry
+        if: ${{ inputs.baseImageRegistry }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.baseImageRegistry }}
+          username: ${{ secrets.baseImageRegistryUsername }}
+          password: ${{ secrets.baseImageRegistryPassword }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Configure AWS credentials

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -43,9 +43,6 @@ on:
       npmGithubReadToken:
         required: true
         description: The Github token with permissions to read NPM private packages
-      AWS_ROLE_TO_ASSUME:
-        required: true
-        description: AWS OIDC role for GitHub to assume
       baseImageRegistryUsername:
         required: false
         description: The username for the base image registry

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -172,7 +172,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml@chore--allow-additional-base-image-registry-for-dh.io
+    uses: parcelLab/ci/.github/workflows/build-image.yaml
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -121,7 +121,7 @@ on:
         required: false
         description: The password for the base image registry
       AWS_ROLE_TO_ASSUME:
-        required: false
+        required: true
         description: AWS OIDC role for GitHub to assume
 
 jobs:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -169,7 +169,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml@v8.2.5
+    uses: parcelLab/ci/.github/workflows/build-image.yaml@chore--allow-additional-base-image-registry-for-dh.io
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -120,6 +120,9 @@ on:
       baseImageRegistryPassword:
         required: false
         description: The password for the base image registry
+      AWS_ROLE_TO_ASSUME:
+        required: false
+        description: AWS OIDC role for GitHub to assume
 
 jobs:
   initialize:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -175,7 +175,6 @@ jobs:
       artifactPath: ${{ inputs.artifactPath }}
       imageTargets: ${{ inputs.imageTargets }}
       preScript: ${{ inputs.preScript }}
-      registryUsername: ${{ inputs.registryUsername }}
       enableContainerScan: ${{ inputs.enableContainerScan }}
       runner: ${{ inputs.runner }}
       baseImageRegistry: ${{ inputs.baseImageRegistry }}

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -97,6 +97,10 @@ on:
         description: The relative file path to the folder that holds the application Kubernetes values
         default: values.yaml
         type: string
+      baseImageRegistry:
+        required: false
+        description: Additional registry to log into for pulling base images
+        type: string
     secrets:
       npmGithubReadToken:
         required: true
@@ -110,9 +114,12 @@ on:
       sentryAuthToken:
         required: false
         description: Authentication token for Sentry
-      AWS_ROLE_TO_ASSUME:
-        required: true
-        description: AWS OIDC role for GitHub to assume
+      baseImageRegistryUsername:
+        required: false
+        description: The username for the base image registry
+      baseImageRegistryPassword:
+        required: false
+        description: The password for the base image registry
 
 jobs:
   initialize:
@@ -171,6 +178,7 @@ jobs:
       registryUsername: ${{ inputs.registryUsername }}
       enableContainerScan: ${{ inputs.enableContainerScan }}
       runner: ${{ inputs.runner }}
+      baseImageRegistry: ${{ inputs.baseImageRegistry }}
       version: ${{ needs.initialize.outputs.version }}
     secrets: inherit
 

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -172,7 +172,7 @@ jobs:
 
   build:
     needs: [initialize]
-    uses: parcelLab/ci/.github/workflows/build-image.yaml
+    uses: parcelLab/ci/.github/workflows/build-image.yaml@v8.2
     with:
       artifactName: ${{ inputs.artifactName }}
       artifactPath: ${{ inputs.artifactPath }}


### PR DESCRIPTION
needs to have the reference to this branch removd in kubernetes.yaml before merging:

`    uses: parcelLab/ci/.github/workflows/build-image.yaml@chore--allow-additional-base-image-registry-for-dh.io
`