### PR TITLE
fix: move empty-diff guard before git commit in kubernetes.yaml

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -252,6 +252,10 @@ jobs:
           git config user.email "$GIT_USER_EMAIL"
           git config user.name "$GIT_USER_NAME"
           git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
           git commit -m "chore(deploy): set $ENV image tag to $VERSION"
           if [ "$PUSH_TO_ENV_TAG" = "true" ]; then
             echo "Set new image tag to $ENV"
@@ -259,10 +263,6 @@ jobs:
             git tag -fa "$ENV" -m "$ENV deploy $VERSION ($NEW_SHA)" "$NEW_SHA"
             git push origin -f "refs/tags/$ENV"
           else
-            if git diff --cached --quiet; then
-              echo "No changes to commit"
-              exit 0
-            fi
             git push origin main
           fi
         env:


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description

PR #82 added an **empty-diff** guard to the commit job in `kubernetes.yaml`, but placed it after git commit. After a commit, the staged index is clean by definition, so `git diff --cached --quiet` always passes and the script exits before `git push origin main`. Every consumer of `@v8` has been silently creating the bot commit on the runner and throwing it away — Actions runs are green but origin/main never updates and the chart never bumps.

This moves the guard to right after git add ., where it actually short-circuits when there is nothing new to deploy, and removes it from the else branch where it was a no-op. Applies to both the env-tag and regular main paths.

PR #81 removed the original guard (which had been correctly placed before git commit).
PR #82 re-added it, but in the else branch after the commit — where the check is always true.

