### PR TITLE
chore: INF-3767 split release workflow in two

### DIFF
--- a/.github/workflows/ci.release.yaml
+++ b/.github/workflows/ci.release.yaml
@@ -1,4 +1,4 @@
-name: Update major tag and release
+name: Prepare the release
 on:
   push:
     branches:
@@ -8,35 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-major-tag:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Extract major version
-        id: version
-        run: |
-          # Get the latest tag created by the release job
-          TAG_NAME="$(git describe --tags --abbrev=0)"
-          echo "Retrieved tag: $TAG_NAME"
-          # Extract major version (e.g., v8.2.7 -> v8)
-          MAJOR_VERSION="$(echo "$TAG_NAME" | sed -E 's/^v([0-9]+)\..*/v\1/')"
-          echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
-          echo "full_version=$TAG_NAME" >> "$GITHUB_OUTPUT"
-      - name: Update major version tag
-        run: |
-          git config user.name "parcellab-dev-bot"
-          git config user.email "dev.bot@parcellab.com"
-
-          # Delete existing major version tag if it exists
-          git tag -d "${{ steps.version.outputs.major_version }}" || true
-          git push -d origin "${{ steps.version.outputs.major_version }}" || true
-
-          # Create new major version tag pointing to the same commit as the full version
-          git tag "${{ steps.version.outputs.major_version }}"
-          git push origin tag "${{ steps.version.outputs.major_version }}"
   release:
     uses: parcelLab/ci/.github/workflows/release.yaml@v8
     secrets:

--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -1,0 +1,36 @@
+name: Update major tag
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract major version
+        id: version
+        run: |
+          # Get the latest tag created by the release job
+          TAG_NAME="$(git describe --tags --abbrev=0)"
+          echo "Retrieved tag: $TAG_NAME"
+          # Extract major version (e.g., v8.2.7 -> v8)
+          MAJOR_VERSION="$(echo "$TAG_NAME" | sed -E 's/^v([0-9]+)\..*/v\1/')"
+          echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
+          echo "full_version=$TAG_NAME" >> "$GITHUB_OUTPUT"
+      - name: Update major version tag
+        run: |
+          git config user.name "parcellab-dev-bot"
+          git config user.email "dev.bot@parcellab.com"
+
+          # Delete existing major version tag if it exists
+          git tag -d "${{ steps.version.outputs.major_version }}" || true
+          git push -d origin "${{ steps.version.outputs.major_version }}" || true
+
+          # Create new major version tag pointing to the same commit as the full version
+          git tag "${{ steps.version.outputs.major_version }}"
+          git push origin tag "${{ steps.version.outputs.major_version }}"


### PR DESCRIPTION
1. `ci.release.yaml` is triggered by merge into `main` and prepares the release
2. `ci.update-major-version-tag.yaml` is triggered by published release and moves the major version tag to the release commit

I'll test how this works after the merge using empty/dummy releases.