### PR TITLE
chore: update github checkout action to v5

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - if: inputs.preScript != ''
         name: Run script before the docker image is built
         run: |
@@ -171,7 +171,7 @@ jobs:
         containerfile_targets: ${{ fromJson(inputs.imageTargets) }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - if: inputs.preScript != ''
         name: Run script before the docker image is built
         run: |
@@ -256,7 +256,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - if: inputs.preScript != ''
         name: Run script before the docker image is built
         run: |

--- a/.github/workflows/ci-requirements.yaml
+++ b/.github/workflows/ci-requirements.yaml
@@ -24,7 +24,7 @@ jobs:
       full_run_required: ${{ steps.check_full_run_required.outputs.full_run_required }}
       test_run_required: ${{ steps.check_test_run_required.outputs.test_run_required }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.pr.yaml
+++ b/.github/workflows/ci.pr.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up go environment
         uses: actions/setup-go@v6
       - name: Install actionlint

--- a/.github/workflows/ci.release.yaml
+++ b/.github/workflows/ci.release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Extract major version

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Validate base image registry secrets
         if: ${{ inputs.baseImageRegistry }}
         run: |

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Load k8s deployment variables
         id: k8s
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,11 +42,11 @@ jobs:
           # shellcheck disable=SC2086
           echo "docs-push-folder=${{ github.workspace }}/remote/repos/${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: this
       - name: Checkout ${{ inputs.docsRepo }} git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: remote
           ref: main

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/json.yaml
+++ b/.github/workflows/json.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Lint JSON
         uses: actionsx/prettier@v3
         with:

--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -235,7 +235,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout ${{ inputs.deploymentRepoURL }} git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.deploymentRepoURL }}
           path: remote

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of REPO_ACCESS_TOKEN
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Label PR based on pushed file paths
         continue-on-error: true
         uses: actions/labeler@v6

--- a/.github/workflows/preview.build-image.yaml
+++ b/.github/workflows/preview.build-image.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Download build artifact
         if: inputs.artifactPath != '' && inputs.artifactName != ''
         uses: actions/download-artifact@v8

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.pythonVersion }}

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -17,6 +17,6 @@ jobs:
     container: koalaman/shellcheck-alpine:v0.9.0
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Check shell scripts
         run: 'find . -type f \( -name "*.sh" \) ${{ inputs.findCommandExtraArgs }} -print | while IFS="" read -r file; do shellcheck "$file"; done;'

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Lint all YAML files
         uses: actionsx/prettier@v3


### PR DESCRIPTION
why not v6? because self-hosted GitHub actions runner might not work with v6