### PR TITLE
chore: make dependabot ignore patch and minor version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,5 @@ updates:
     ignore:
       # This tells Dependabot to ignore patch and minor bumps for all GHA dependencies, so it won't try to pin v8.3.7 — only major version bumps (e.g. v8 → v9) would trigger a PR
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     commit-message:
       prefix: "chore(actions)"
       include: "scope"
+    ignore:
+      # This tells Dependabot to ignore patch and minor bumps for all GHA dependencies, so it won't try to pin v8.3.7 — only major version bumps (e.g. v8 → v9) would trigger a PR
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
We're getting a lot of noise with Dependabot updating minor/patch versions, and it's trying to pin the exact latest version for our reusable internal workflows.

This PR makes Dependabot only consider major version updates.