### PR TITLE
fix: harden major-tag update (release: published)

### DIFF
--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -1,8 +1,18 @@
 name: Update major tag
 on:
-  release:
-    types:
-      - published
+  # Fire when the semver tag itself is created (i.e. on publish). A draft
+  # release does not create its git tag, so this never runs for drafts, and it
+  # is immune to the GITHUB_TOKEN anti-recursion that can swallow the
+  # `release: published` event (see v8.3.8, which left v8 a release behind).
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  # Manual recovery lever to realign the major tag to a specific version.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Semver tag to align the major tag to (e.g. v8.3.8)"
+        required: true
 
 jobs:
   update-major-tag:
@@ -15,10 +25,11 @@ jobs:
       - name: Extract major version
         id: version
         run: |
-          # Get the latest tag created by the release job
-          TAG_NAME="$(git describe --tags --abbrev=0)"
-          echo "Retrieved tag: $TAG_NAME"
-          # Extract major version (e.g., v8.2.7 -> v8)
+          # Use the pushed tag ref (or the dispatch input) directly; no
+          # `git describe` topology guesswork.
+          TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "Resolved tag: $TAG_NAME"
+          # Extract major version (e.g. v8.2.7 -> v8)
           MAJOR_VERSION="$(echo "$TAG_NAME" | sed -E 's/^v([0-9]+)\..*/v\1/')"
           echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "full_version=$TAG_NAME" >> "$GITHUB_OUTPUT"
@@ -27,10 +38,6 @@ jobs:
           git config user.name "parcellab-dev-bot"
           git config user.email "dev.bot@parcellab.com"
 
-          # Delete existing major version tag if it exists
-          git tag -d "${{ steps.version.outputs.major_version }}" || true
-          git push -d origin "${{ steps.version.outputs.major_version }}" || true
-
-          # Create new major version tag pointing to the same commit as the full version
-          git tag "${{ steps.version.outputs.major_version }}"
-          git push origin tag "${{ steps.version.outputs.major_version }}"
+          # Point the major version tag at the resolved full version commit.
+          git tag -f "${{ steps.version.outputs.major_version }}" "${{ steps.version.outputs.full_version }}"
+          git push origin -f "refs/tags/${{ steps.version.outputs.major_version }}"

--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -4,16 +4,22 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:
         description: "Semver tag to align the major tag to (e.g. v8.3.8)"
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.release.prerelease == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -22,7 +28,7 @@ jobs:
       - name: Extract major version
         id: version
         run: |
-          TAG_NAME="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          TAG_NAME="${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}"
           echo "Resolved tag: $TAG_NAME"
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::notice::'$TAG_NAME' is not a release semver tag (vX.Y.Z); skipping major-tag update."

--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -1,15 +1,10 @@
 name: Update major tag
 on:
-  # Fire when the semver tag itself is created (i.e. on publish). A draft
-  # release does not create its git tag, so this never runs for drafts, and it
-  # is immune to the GITHUB_TOKEN anti-recursion that can swallow the
-  # `release: published` event (see v8.3.8, which left v8 a release behind).
-  # NOTE: tag filters are globs, not regex — `*` matches any chars, `[0-9]` a
-  # digit. The exact semver shape is enforced in the job below.
+  # Trigger on tag push, not `release: published` — that event is suppressed by GITHUB_TOKEN anti-recursion and left v8 a release behind (build-image input break).
   push:
     tags:
+      # Glob filter, not regex (`+`/`.` are literal). Exact semver enforced in the job.
       - "v[0-9]*.[0-9]*.[0-9]*"
-  # Manual recovery lever to realign the major tag to a specific version.
   workflow_dispatch:
     inputs:
       tag:
@@ -19,8 +14,6 @@ on:
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
-    # Skip tag deletions (push events with deleted=true): the ref is gone and
-    # there is nothing to realign to. Only run on tag creation or manual dispatch.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.created }}
     steps:
       - name: Checkout
@@ -30,18 +23,13 @@ jobs:
       - name: Extract major version
         id: version
         run: |
-          # Use the pushed tag ref (or the dispatch input) directly; no
-          # `git describe` topology guesswork.
           TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
           echo "Resolved tag: $TAG_NAME"
-          # Enforce a strict semver release tag (no pre-release/build suffix) so
-          # the major tag never tracks a pre-release.
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::notice::'$TAG_NAME' is not a release semver tag (vX.Y.Z); skipping major-tag update."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Extract major version (e.g. v8.2.7 -> v8)
           MAJOR_VERSION="$(echo "$TAG_NAME" | sed -E 's/^v([0-9]+)\..*/v\1/')"
           echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "full_version=$TAG_NAME" >> "$GITHUB_OUTPUT"
@@ -51,6 +39,5 @@ jobs:
           git config user.name "parcellab-dev-bot"
           git config user.email "dev.bot@parcellab.com"
 
-          # Point the major version tag at the resolved full version commit.
           git tag -f "${{ steps.version.outputs.major_version }}" "${{ steps.version.outputs.full_version }}"
           git push origin -f "refs/tags/${{ steps.version.outputs.major_version }}"

--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -4,9 +4,11 @@ on:
   # release does not create its git tag, so this never runs for drafts, and it
   # is immune to the GITHUB_TOKEN anti-recursion that can swallow the
   # `release: published` event (see v8.3.8, which left v8 a release behind).
+  # NOTE: tag filters are globs, not regex — `*` matches any chars, `[0-9]` a
+  # digit. The exact semver shape is enforced in the job below.
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]*.[0-9]*.[0-9]*"
   # Manual recovery lever to realign the major tag to a specific version.
   workflow_dispatch:
     inputs:
@@ -17,6 +19,9 @@ on:
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
+    # Skip tag deletions (push events with deleted=true): the ref is gone and
+    # there is nothing to realign to. Only run on tag creation or manual dispatch.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,11 +34,19 @@ jobs:
           # `git describe` topology guesswork.
           TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
           echo "Resolved tag: $TAG_NAME"
+          # Enforce a strict semver release tag (no pre-release/build suffix) so
+          # the major tag never tracks a pre-release.
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::'$TAG_NAME' is not a release semver tag (vX.Y.Z); skipping major-tag update."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Extract major version (e.g. v8.2.7 -> v8)
           MAJOR_VERSION="$(echo "$TAG_NAME" | sed -E 's/^v([0-9]+)\..*/v\1/')"
           echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "full_version=$TAG_NAME" >> "$GITHUB_OUTPUT"
       - name: Update major version tag
+        if: ${{ steps.version.outputs.skip != 'true' }}
         run: |
           git config user.name "parcellab-dev-bot"
           git config user.email "dev.bot@parcellab.com"

--- a/.github/workflows/ci.update-major-version-tag.yaml
+++ b/.github/workflows/ci.update-major-version-tag.yaml
@@ -1,10 +1,9 @@
 name: Update major tag
 on:
-  # Trigger on tag push, not `release: published` — that event is suppressed by GITHUB_TOKEN anti-recursion and left v8 a release behind (build-image input break).
-  push:
-    tags:
-      # Glob filter, not regex (`+`/`.` are literal). Exact semver enforced in the job.
-      - "v[0-9]*.[0-9]*.[0-9]*"
+  # `release: published` is suppressed when the release is published by the default GITHUB_TOKEN — publish releases as a human (or PAT), never via GITHUB_TOKEN, or v8 silently lags behind.
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       tag:
@@ -14,7 +13,7 @@ on:
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.created }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,7 +22,7 @@ jobs:
       - name: Extract major version
         id: version
         run: |
-          TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_NAME="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           echo "Resolved tag: $TAG_NAME"
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::notice::'$TAG_NAME' is not a release semver tag (vX.Y.Z); skipping major-tag update."


### PR DESCRIPTION
## Problem

The `v8` major tag silently fell a release behind after **v8.3.8**.

`ci.update-major-version-tag.yaml` triggers `on: release: published`, but that event is **suppressed when the release is published by the default `GITHUB_TOKEN`** (GitHub anti-recursion). The v8.3.8 release was published via automation, so the workflow never ran — leaving `v8` pinned to v8.3.7's commit.

Because PR #127 added the `timeoutMinutes` input to `build-image.yaml` **in v8.3.8**, `kubernetes.yaml@v8.3.8` forwarding `timeoutMinutes` to `build-image.yaml@v8` (still v8.3.7, no such input) failed validation for every consumer:

> Invalid input, timeoutMinutes is not defined in the referenced workflow.

(`v8` has already been manually realigned to v8.3.8 to unblock consumers; this PR prevents recurrence.)

## Approach

Releases are created/published **manually by a human**, so the `GITHUB_TOKEN` suppression does not apply to the normal flow — a person publishing in the UI fires the event reliably. We therefore **keep `release: published`** (semantically correct, won't fire on stray tag pushes) and harden the weak parts instead.

## Changes

- Take the version from **`github.event.release.tag_name`** instead of the fragile `git describe --tags --abbrev=0` topology guess.
- Enforce strict `vX.Y.Z` semver and **skip pre-releases** (`github.event.release.prerelease`).
- Add a **`workflow_dispatch`** input to realign the major tag by hand if an event is ever missed (the v8.3.8 recovery path).
- Use an idempotent `git tag -f` + force-push instead of delete-then-recreate.

## Operational note

Publish releases as a **human (or PAT), never via the default `GITHUB_TOKEN`** — otherwise the `release: published` event is suppressed and `v8` lags behind again.