### PR TITLE
chore: make AWS_ROLE_TO_ASSUME secret optional

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -69,7 +69,7 @@ on:
         required: false
         description: The Github token with permissions to read NPM private packages
       AWS_ROLE_TO_ASSUME:
-        required: true
+        required: false
         description: AWS OIDC role for GitHub to assume
       baseImageRegistryUsername:
         required: false

--- a/.github/workflows/preview.build-image.yaml
+++ b/.github/workflows/preview.build-image.yaml
@@ -32,7 +32,7 @@ on:
         type: number
     secrets:
       AWS_ROLE_TO_ASSUME:
-        required: true
+        required: false
         description: AWS OIDC role for GitHub to assume
 
 jobs:

--- a/.github/workflows/preview.remove-tag.yaml
+++ b/.github/workflows/preview.remove-tag.yaml
@@ -14,7 +14,7 @@ on:
         type: number
     secrets:
       AWS_ROLE_TO_ASSUME:
-        required: true
+        required: false
         description: AWS OIDC role for GitHub to assume
 
 jobs:


### PR DESCRIPTION
`AWS_ROLE_TO_ASSUME` secret is no longer in use - we use org-wide GH variable directly at `role-to-assume` parameter.
This PR initiates a process of it's deprecation.

To avoid disruption, this change needs to happen in 3 phases:
1. Set `required` parameter to `false` - current PR handles it
2. Remove secret in all consumer workflows - this requires a PR per each consumer repo
3. Remove secret from reusable workflows - https://github.com/parcelLab/ci/pull/138
